### PR TITLE
Fix memory leak

### DIFF
--- a/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.h
+++ b/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.h
@@ -19,4 +19,6 @@
 @property (nonatomic) NSURLSession *session;
 @property (nonatomic) NSTimeInterval networkTimeout;
 
+- (void)cancelRequests;
+
 @end

--- a/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
+++ b/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
@@ -61,6 +61,11 @@ static NSTimeInterval const kDefaultLoadingTimeout = 15;
     return NSStringFromClass(self);
 }
 
+- (void)cancelRequests {
+    [self.session invalidateAndCancel];
+    self.session = nil;
+}
+
 #pragma mark - Resource loader delegate
 
 - (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader shouldWaitForLoadingOfRequestedResource:(AVAssetResourceLoadingRequest *)loadingRequest {

--- a/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
+++ b/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
@@ -139,9 +139,11 @@ static NSTimeInterval const kDefaultLoadingTimeout = 15;
         NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request];
         [dataTask resume];
 
-        [self.datas addObject:[NSMutableData new]];
-        [self.dataTasks addObject:dataTask];
-        [self.pendingRequests addObject:loadingRequest];
+        if (dataTask) {
+            [self.datas addObject:[NSMutableData new]];
+            [self.dataTasks addObject:dataTask];
+            [self.pendingRequests addObject:loadingRequest];
+        }
 
         return YES;
     }

--- a/DVAssetLoaderDelegate/Classes/DVURLAsset.m
+++ b/DVAssetLoaderDelegate/Classes/DVURLAsset.m
@@ -10,6 +10,12 @@
 
 static NSTimeInterval const kDefaultLoadingTimeout = 15;
 
+@interface DVURLAsset()
+
+@property (nonatomic, readonly) DVAssetLoaderDelegate *resourceLoaderDelegate;
+
+@end
+
 @implementation DVURLAsset
 
 - (instancetype)initWithURL:(NSURL *)URL options:(NSDictionary<NSString *,id> *)options {
@@ -37,11 +43,19 @@ static NSTimeInterval const kDefaultLoadingTimeout = 15;
 }
 
 - (void)setLoaderDelegate:(NSObject<DVAssetLoaderDelegatesDelegate> *)loaderDelegate {
-    ((DVAssetLoaderDelegate *)self.resourceLoader.delegate).delegate = loaderDelegate;
+    self.resourceLoaderDelegate.delegate = loaderDelegate;
 }
 
 - (NSObject<DVAssetLoaderDelegatesDelegate> *)loaderDelegate {
-    return ((DVAssetLoaderDelegate *)self.resourceLoader.delegate).delegate;
+    return self.resourceLoaderDelegate.delegate;
+}
+
+- (DVAssetLoaderDelegate *)resourceLoaderDelegate {
+    if ([self.resourceLoader.delegate isKindOfClass:[DVAssetLoaderDelegate class]]) {
+        return (DVAssetLoaderDelegate *)self.resourceLoader.delegate;
+    }
+    return nil;
+}
 }
 
 @end

--- a/DVAssetLoaderDelegate/Classes/DVURLAsset.m
+++ b/DVAssetLoaderDelegate/Classes/DVURLAsset.m
@@ -56,6 +56,9 @@ static NSTimeInterval const kDefaultLoadingTimeout = 15;
     }
     return nil;
 }
+
+- (void)dealloc {
+    [self.resourceLoaderDelegate cancelRequests];
 }
 
 @end


### PR DESCRIPTION
I found that memory leaks happens, when DVAssetLoaderDelegate calls to self.session for creating new requests tasks, after DVURLAsset deallocated.
My trying to fix this problem in this PR.
Proof from NSURLSession:
> Customization of NSURLSession occurs during creation of a new session.
> If you only need to use the convenience routines with custom
> configuration options it is not necessary to specify a delegate.
> If you do specify a delegate, the delegate will be retained until after
> the delegate has been sent the URLSession:didBecomeInvalidWithError: message.
I found that message URLSession:didBecomeInvalidWithError: didn't called in some cases.