### PR TITLE
Updates scheme access to avoid meta class changes

### DIFF
--- a/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
+++ b/DVAssetLoaderDelegate/Classes/DVAssetLoaderDelegate.m
@@ -69,7 +69,7 @@ static NSTimeInterval const kDefaultLoadingTimeout = 15;
 #pragma mark - Resource loader delegate
 
 - (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader shouldWaitForLoadingOfRequestedResource:(AVAssetResourceLoadingRequest *)loadingRequest {
-    if (![loadingRequest.request.URL.scheme isEqualToString:[[self class] scheme]]) {
+    if (![loadingRequest.request.URL.scheme isEqualToString:[DVAssetLoaderDelegate scheme]]) {
         return NO;
     }
     


### PR DESCRIPTION
I have come across an instance where a 3rd party library impacted the resource loading mechanism. Specifically, I was using the library [FirebasePerformance](https://firebase.google.com/docs/perf-mon/get-started-ios). When this library is installed next to `DVAssetLoaderDelegate` the asset fails to load. This occurs because FirebasePerformance is doing some manipulation to the class meta data for tracking. The issue is due to the way that `DVAssetLoaderDelegate` references the `scheme` property differently. When referencing the class property `scheme` it looks correct `DVAssetLoaderDelegate`. However, when the `scheme` property is accessed by `[self class]` the output looks like this `fir_<UUID>_DVAssetLoaderDelegate`. And because of this the `isEqualToString` check fails.